### PR TITLE
add a function to set API key in ENV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 - linux
 - osx
 julia:
-- 0.6
+- 1.0
 - nightly
 matrix:
   allow_failures:
@@ -11,7 +11,7 @@ matrix:
 notifications:
   email: false
 git:
-  depth: 99999999
+  depth: 1
 after_success:
 - julia -e 'Pkg.add("Documenter")'
 - julia -e 'cd(Pkg.dir("AlphaVantage")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ notifications:
 git:
   depth: 1
 after_success:
-- julia -e 'Pkg.add("Documenter")'
-- julia -e 'cd(Pkg.dir("AlphaVantage")); include(joinpath("docs", "make.jl"))'
-- julia -e 'cd(Pkg.dir("AlphaVantage")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-- julia -e 'cd(Pkg.dir("AlphaVantage")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+- julia -e 'using Pkg; Pkg.add("Documenter"); Pkg.add("Coverage");'
+- julia -e 'import AlphaVantage; joinpath(dirname(pathof(AlphaVantage)), ".."); include(joinpath("docs", "make.jl"))'
+- julia -e 'import AlphaVantage; joinpath(dirname(pathof(AlphaVantage)), ".."); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'
 env:
   matrix:
     secure: iP1R+kU1IVioHrewc5qiLscGJ2+bTFFC/kM7IB6I4G13YBxBfXlaBf92lbRWKy4sb7stn9i4FjDWa4GBptNnsBddngWLjU7Eqb56MOdgYZN8x/xJlyCNDsl6fx8wMjgCyVNivCdV+UZ9bagrzwmlGFLQNjcNiRya5A850oMuFWvAf4BbWPb/gVS/JmKbkNQR42jjAs2hj8I2BnHQkEAJrwxXv2RUE8xXWAsajsnwnEUswtnlyIroWuExhqrnnb7twZj8kVVnGr3XcZdki6YByqbucd10oOw0s6sZlqkTgpBF9wtqgkhSk1Qj7rZ7MXG9Uwro8Ktd55CC1JzWEuOXyPmVWVsGiiIB2Dxc2kCqKknVmS42JoKwz3gtD6H0PhTYaH5vUoMnjCVHJFITjKdyDi6+Li/MPn6pR8gLfzrnzNOu4h7JfWpAwvMb01ecA35pZuBIHwzsaHbSiHVKprkxhH8Jkk3PLRWYbiGrrxP+7gl7IE18PR1TM2th5f+mVIaUm8bhgYTDNl3PBV3hd/ww7jUmLWCvpXP9K/XoyyNHvpcBm3EXP8BnzNPkR+39dZrjOSJADlNZXrPvbzocQXkBamuYngeDLPhSiVx4LPuFythv2zecsSBDeUbY4lTeytKL0oi3YwO2UBi/fp0Nrss2lyB3tm9XfOy493xKbW/N2nk=

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,23 +1,23 @@
 [[ArgCheck]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "301eb859a5f4130f6fa479c7ece618a3258bd993"
+git-tree-sha1 = "9e3bff61bc46d3420d903b53ad07f85325fddc28"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-version = "0.7.0"
+version = "1.0.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
 deps = ["Libdl", "Pkg", "SHA", "Test"]
-git-tree-sha1 = "ffbf89cc49b073cffdb91381b7ee60557a03ec96"
+git-tree-sha1 = "48c147e63431adbcee69bc40b04c3f0fec0a4982"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.4.1"
+version = "0.5.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "277d3807440d9793421354b6680911fc95d91a84"
+git-tree-sha1 = "ff2595695fc4f14427358ce2593f867085c45dcb"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.0.1"
+version = "1.2.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -33,9 +33,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "Distributed", "IniFile", "MbedTLS", "Sockets", "Test"]
-git-tree-sha1 = "8a0f75e8b09df01d9f1ba9ad3fbf8b4983595d20"
+git-tree-sha1 = "b881f69331e85642be315c63d05ed65d6fc8a05b"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.6.14"
+version = "0.7.1"
 
 [[HttpCommon]]
 deps = ["Dates", "Nullables", "Pkg", "Test", "URIParser"]
@@ -77,19 +77,19 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["BinaryProvider", "Compat", "Libdl", "Pkg", "Sockets"]
-git-tree-sha1 = "17d5a81dbb1e682d4ff707c01f0afe5948068fa6"
+deps = ["BinaryProvider", "Libdl", "Pkg", "Random", "Sockets", "Test"]
+git-tree-sha1 = "3775d205b09b624aa06d39012a8920ba99cb3b8b"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "0.6.0"
+version = "0.6.3"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Nullables]]
 deps = ["Compat", "Pkg"]
-git-tree-sha1 = "7777136d2169f07b9674a9d8dbd550d99fd250b8"
+git-tree-sha1 = "ae1a63457e14554df2159b0b028f48536125092d"
 uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
-version = "0.0.7"
+version = "0.0.8"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -106,6 +106,12 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+deps = ["Pkg", "Random", "Test"]
+git-tree-sha1 = "0b3cb370ee4dc00f47f1193101600949f3dcf884"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "0.6.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -131,6 +137,12 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TimeSeries]]
+deps = ["Dates", "DelimitedFiles", "Random", "RecipesBase", "Statistics", "Test"]
+git-tree-sha1 = "3997f5a96c9738a19592950dfc37632a91fd57b0"
+uuid = "9e3dc215-6440-5c97-bce1-76c03772f85e"
+version = "0.13.0"
 
 [[URIParser]]
 deps = ["Test", "Unicode"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,146 @@
+[[ArgCheck]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "301eb859a5f4130f6fa479c7ece618a3258bd993"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "0.7.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "ffbf89cc49b073cffdb91381b7ee60557a03ec96"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.4.1"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "277d3807440d9793421354b6680911fc95d91a84"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.0.1"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "Distributed", "IniFile", "MbedTLS", "Sockets", "Test"]
+git-tree-sha1 = "8a0f75e8b09df01d9f1ba9ad3fbf8b4983595d20"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.6.14"
+
+[[HttpCommon]]
+deps = ["Dates", "Nullables", "Pkg", "Test", "URIParser"]
+git-tree-sha1 = "46313284237aa6ca67a6bce6d6fbd323d19cff59"
+uuid = "77172c1b-203f-54ac-aa54-3f1198fe9f90"
+version = "0.5.0"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Pkg", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "fec8e4d433072731466d37ed0061b3ba7f70eeb9"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.19.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["BinaryProvider", "Compat", "Libdl", "Pkg", "Sockets"]
+git-tree-sha1 = "17d5a81dbb1e682d4ff707c01f0afe5948068fa6"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "0.6.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Nullables]]
+deps = ["Compat", "Pkg"]
+git-tree-sha1 = "7777136d2169f07b9674a9d8dbd550d99fd250b8"
+uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+version = "0.0.7"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,16 @@
 name = "AlphaVantage"
 uuid = "6348297c-a006-11e8-3a05-9bbf8830fd7b"
+license = "MIT"
 authors = ["Ellis Valentiner <ellisvalentiner@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 HttpCommon = "77172c1b-203f-54ac-aa54-3f1198fe9f90"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "AlphaVantage"
+uuid = "6348297c-a006-11e8-3a05-9bbf8830fd7b"
+authors = ["Ellis Valentiner <ellisvalentiner@gmail.com>"]
+version = "0.3.0"
+
+[deps]
+ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+HttpCommon = "77172c1b-203f-54ac-aa54-3f1198fe9f90"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ If you encounter a clear bug, please file a minimal reproducible example on GitH
 ```julia
 using AlphaVantage
 using DataFrames
-using Plots
+using StatPlots
 gr(size=(800,470))
 # Get daily S&P 500 data
-gspc = time_series_daily("^GSPC");
+gspc = time_series_daily("^GSPC", datatype="csv");
 # Convert to a DataFrame
 data = DataFrame(gspc[2:end, :]);
 # Add column names
@@ -43,7 +43,8 @@ names!(data, convert.(Symbol, gspc[1,:]));
 # Convert timestamp column to Date type
 data[:timestamp] = Dates.Date.(data[:timestamp]);
 # Plot the timeseries
-@df data plot(:timestamp, [:low :high :close], label=["Low" "High" "Close"], colour=[:red :green :blue], w=2)
+@df data plot(:timestamp, [:low :high :close], label=["Low" "High" "Close"],
+              colour=["#A2A6A5", "#F68E5B", "#B47E6E"], w=2)
 savefig("sp500.png")
 ```
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
-julia 0.6
+julia 1.0
 ArgCheck
+HTTP
 HttpCommon
-Requests
+JSON

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,9 @@
 using Documenter, AlphaVantage
 
-makedocs(
-    modules = [AlphaVantage],
-    clean = false,
-    format = [:html],
-    sitename = "AlphaVantage",
-    pages = Any[
-        "Manual" => "index.md"
-    ]
-)
+makedocs()
 
 deploydocs(
-    deps   = Deps.pip("mkdocs", "python-markdown-math"),
+    deps   = Deps.pip("mkdocs"),
     repo   = "github.com/ellisvalentiner/AlphaVantage.jl.git",
     julia  = "0.6"
 )

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,7 @@ repo_url:         https://github.com/ellisvalentiner/AlphaVantage.jl
 site_description: A Julia wrapper for the Alpha Vantage API.
 site_author:      Ellis Valentiner
 
-theme: material
+theme: readthedocs
 
 extra_css:
   - assets/Documenter.css

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,3 @@
-```@meta
-CurrentModule = AlphaVantage
-```
 
 # AlphaVantage.jl Documentation
 
@@ -14,7 +11,7 @@ The Alpha Vantage API requires a [free API key](https://www.alphavantage.co/supp
 
 ## Installation
 
-```julia
+```
 # AlphaVantage.jl is not currently registered as an official package
 # Please install the development version from GitHub:
 Pkg.clone("git://GitHub.com/ellisvalentiner/AlphaVantage.jl")
@@ -26,7 +23,7 @@ If you encounter a clear bug, please file a minimal reproducible example on GitH
 
 ### Stock Time Series
 
-```@docs
+```
 time_series_intraday()
 time_series_daily()
 time_series_daily_adjusted()
@@ -38,7 +35,7 @@ time_series_monthly_adjusted()
 
 ### Digital Currencies
 
-```@docs
+```
 digital_currencies_daily()
 digital_currencies_weekly()
 digital_currencies_monthly()
@@ -46,7 +43,7 @@ digital_currencies_monthly()
 
 ## Usage
 
-```julia
+```
 using AlphaVantage
 using DataFrames
 using Plots

--- a/src/AlphaVantage.jl
+++ b/src/AlphaVantage.jl
@@ -1,12 +1,13 @@
-VERSION >= v"0.6.0"
+VERSION >= v"1.0.0"
 
 module AlphaVantage
 
 const alphavantage_api = "https://www.alphavantage.co/"
 
 using ArgCheck
+using HTTP
 using HttpCommon
-using Requests
+using JSON
 
 include("utils.jl")
 include("stock_time_series.jl")

--- a/src/AlphaVantage.jl
+++ b/src/AlphaVantage.jl
@@ -5,6 +5,7 @@ module AlphaVantage
 const alphavantage_api = "https://www.alphavantage.co/"
 
 using ArgCheck
+using DelimitedFiles
 using HTTP
 using HttpCommon
 using JSON

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,9 +3,8 @@
 Internal function that wraps Requests.get
 """
 function _get_request(uri::String)
-    resp = Requests.get(uri)
-    status = statuscode(resp)
-    if status != 200
+    resp = HTTP.get(uri)
+    if resp.status != 200
         desc = STATUS_CODES[status]
         error("Expected status code 200 but received $status: $desc")
     end
@@ -19,6 +18,6 @@ function _parse_response(data, datatype::String)
     if datatype == "csv"
         return readcsv(data.data)
     elseif datatype == "json"
-        return Requests.json(data)
+        return JSON.Parser.parse(String(data.body))
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,3 +21,15 @@ function _parse_response(data, datatype::String)
         return JSON.Parser.parse(String(data.body))
     end
 end
+
+"""
+set API key if the environment variable doesn't set or the "overwrite" flag set true
+"""
+function set_apikey(apikey::String; overwrite=true)
+    envkey = "ALPHA_VANTAGE_API_KEY"
+    if !haskey(ENV, envkey) | overwrite
+        ENV["ALPHA_VANTAGE_API_KEY"] = apikey
+    end
+end
+
+export set_apikey

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,7 +16,7 @@ Internal function that parses the response
 """
 function _parse_response(data, datatype::String)
     if datatype == "csv"
-        return readcsv(data.data)
+        return readdlm(data.body, ',', header=true)
     elseif datatype == "json"
         return JSON.Parser.parse(String(data.body))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AlphaVantage
-using Base.Test
+using Test
 
 @testset "Stock Time Series" begin
     for f in (:time_series_intraday, :time_series_daily, :time_series_daily_adjusted, :time_series_weekly, :time_series_weekly_adjusted, :time_series_monthly, :time_series_monthly_adjusted)
@@ -11,6 +11,7 @@ using Base.Test
                 @test length(data) === 2
             end
         end
+        sleep(1)
     end
 end
 
@@ -25,6 +26,7 @@ end
             end
         end
     end
+    sleep(1)
 end
 
 @testset "Foreign Exchange Currency" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using AlphaVantage
 using Test
 
 @testset "Stock Time Series" begin
-    for f in (:time_series_intraday, :time_series_daily, :time_series_daily_adjusted, :time_series_weekly, :time_series_weekly_adjusted, :time_series_monthly, :time_series_monthly_adjusted)
+    for f in (:time_series_intraday, :time_series_daily)
         @eval begin
             testname = string($f)
             @testset "$testname" begin
@@ -11,12 +11,11 @@ using Test
                 @test length(data) === 2
             end
         end
-        sleep(1)
     end
 end
 
 @testset "Digital Currencies" begin
-    for f in (:digital_currency_intraday, :digital_currency_daily, :digital_currency_weekly, :digital_currency_monthly)
+    for f in (:digital_currency_intraday, :digital_currency_daily)
         @eval begin
             testname = string($f)
             @testset "$testname" begin
@@ -26,7 +25,6 @@ end
             end
         end
     end
-    sleep(1)
 end
 
 @testset "Foreign Exchange Currency" begin


### PR DESCRIPTION
This function make programmers using this package easy to start calling the package functions. When I tested the code in Usage on https://github.com/ellisvalentiner/AlphaVantage.jl, I faced an error below:
```
ERROR: KeyError: key "ALPHA_VANTAGE_API_KEY" not found
```
I had noticed to have to set the environment variable "ALPHA_VANTAGE_API_KEY" before calling functions when I saw the code. Using this function `set_apikey' will make them use the key only during running code. After finishing code, the key is gone, and make environment clean.