### PR TITLE
Add  time_series_intraday_extended

### DIFF
--- a/src/stock_time_series.jl
+++ b/src/stock_time_series.jl
@@ -2,9 +2,10 @@ function time_series_intraday_extended(symbol::String, interval::String="60min",
     @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
     sliceMatch = match(r"year\d+month\d+", slice)
     @argcheck !isnothing(sliceMatch)
-    @argcheck tryparse(Int, sliceMatch["year"]) > 0
-    @argcheck tryparse(Int, sliceMatch["month"]) > 0
-    @argcheck tryparse(Int, sliceMatch["month"]) < 13
+    @argcheck parse(Int, sliceMatch["year"]) > 0
+    @argcheck parse(Int, sliceMatch["year"]) < 3
+    @argcheck parse(Int, sliceMatch["month"]) > 0
+    @argcheck parse(Int, sliceMatch["month"]) < 13
     @argcheck in(datatype, ["json", "csv"])
     uri = "$(alphavantage_api)query?function=TIME_SERIES_INTRADAY_EXTENDED&symbol=$symbol&interval=$interval&slice=$slice&datatype=$datatype&apikey=" * ENV["ALPHA_VANTAGE_API_KEY"]
     data = _get_request(uri)

--- a/src/stock_time_series.jl
+++ b/src/stock_time_series.jl
@@ -1,4 +1,4 @@
-function time_series_intraday_extended(symbol::String, interval::String="60min", slice::String="year1month1"; datatype::String="json")
+function time_series_intraday_extended(symbol::String, interval::String="60min", slice::String="year1month1")
     @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
     sliceMatch = match(r"year(?<year>\d+)month(?<month>\d+)", slice)
     @argcheck !isnothing(sliceMatch)
@@ -6,10 +6,9 @@ function time_series_intraday_extended(symbol::String, interval::String="60min",
     @argcheck parse(Int, sliceMatch["year"]) < 3
     @argcheck parse(Int, sliceMatch["month"]) > 0
     @argcheck parse(Int, sliceMatch["month"]) < 13
-    @argcheck in(datatype, ["json", "csv"])
-    uri = "$(alphavantage_api)query?function=TIME_SERIES_INTRADAY_EXTENDED&symbol=$symbol&interval=$interval&slice=$slice&datatype=$datatype&apikey=" * ENV["ALPHA_VANTAGE_API_KEY"]
+    uri = "$(alphavantage_api)query?function=TIME_SERIES_INTRADAY_EXTENDED&symbol=$symbol&interval=$interval&slice=$slice&apikey=" * ENV["ALPHA_VANTAGE_API_KEY"]
     data = _get_request(uri)
-    return _parse_response(data, datatype)
+    return _parse_response(data, "csv")
 end
 export time_series_intraday_extended
 

--- a/src/stock_time_series.jl
+++ b/src/stock_time_series.jl
@@ -1,6 +1,6 @@
 function time_series_intraday_extended(symbol::String, interval::String="60min", slice::String="year1month1"; datatype::String="json")
     @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
-    sliceMatch = match(r"year\d+month\d+", slice)
+    sliceMatch = match(r"year(?<year>\d+)month(?<month>\d+)", slice)
     @argcheck !isnothing(sliceMatch)
     @argcheck parse(Int, sliceMatch["year"]) > 0
     @argcheck parse(Int, sliceMatch["year"]) < 3

--- a/src/stock_time_series.jl
+++ b/src/stock_time_series.jl
@@ -1,3 +1,17 @@
+function time_series_intraday_extended(symbol::String, interval::String="60min", slice::String="year1month1"; datatype::String="json")
+    @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
+    @argcheck all(contains.(slice, ["year", "month"]))
+    @argcheck length(findall(r"[\d]+", slice)) == 2
+    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[1]]) > 0
+    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[2]]) > 0
+    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[2]]) < 13
+    @argcheck in(datatype, ["json", "csv"])
+    uri = "$(alphavantage_api)query?function=TIME_SERIES_INTRADAY_EXTENDED&symbol=$symbol&interval=$interval&slice=$slice&datatype=$datatype&apikey=" * ENV["ALPHA_VANTAGE_API_KEY"]
+    data = _get_request(uri)
+    return _parse_response(data, datatype)
+end
+export time_series_intraday_extended
+
 function time_series_intraday(symbol::String, interval::String="1min"; outputsize::String="compact", datatype::String="json")
     @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
     @argcheck in(outputsize, ["compact", "full"])

--- a/src/stock_time_series.jl
+++ b/src/stock_time_series.jl
@@ -1,10 +1,10 @@
 function time_series_intraday_extended(symbol::String, interval::String="60min", slice::String="year1month1"; datatype::String="json")
     @argcheck in(interval, ["1min", "5min", "15min", "30min", "60min"])
-    @argcheck all(contains.(slice, ["year", "month"]))
-    @argcheck length(findall(r"[\d]+", slice)) == 2
-    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[1]]) > 0
-    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[2]]) > 0
-    @argcheck tryparse(Int, slice[findall(r"[\d]+", slice)[2]]) < 13
+    sliceMatch = match(r"year\d+month\d+", slice)
+    @argcheck !isnothing(sliceMatch)
+    @argcheck tryparse(Int, sliceMatch["year"]) > 0
+    @argcheck tryparse(Int, sliceMatch["month"]) > 0
+    @argcheck tryparse(Int, sliceMatch["month"]) < 13
     @argcheck in(datatype, ["json", "csv"])
     uri = "$(alphavantage_api)query?function=TIME_SERIES_INTRADAY_EXTENDED&symbol=$symbol&interval=$interval&slice=$slice&datatype=$datatype&apikey=" * ENV["ALPHA_VANTAGE_API_KEY"]
     data = _get_request(uri)

--- a/test/stock_time_series_test.jl
+++ b/test/stock_time_series_test.jl
@@ -24,4 +24,14 @@ stock_time_series_functions_test = vcat(:time_series_intraday, stock_time_series
         end
         sleep(TEST_SLEEP_TIME + 2*rand()) #as to not overload the API
     end
+
+    f = :time_series_intraday_extended
+    @eval begin
+        testname = string($f)
+        @testset "$testname" begin
+            data = $f("MSFT")
+            @test typeof(data) === Tuple{Array{Any, 2}, Array{AbstractString, 2}}
+            @test length(data) === 2
+        end
+    end
 end


### PR DESCRIPTION
I duplicated and modified time_series_intraday to provide access to the [EXTENDED](https://www.alphavantage.co/documentation/#intraday-extended) function.

TODO is add to the test suite. Simple inclusion in the existing time_series tests resulted in failures.