### PR TITLE
Narrow types so we no longer have `Vector{Any}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "AlphaVantage"
 uuid = "6348297c-a006-11e8-3a05-9bbf8830fd7b"
 license = "MIT"
 authors = ["Ellis Valentiner <ellisvalentiner@gmail.com>", "Dean Markwick <dean.markwick@talk21.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/avresponse.jl
+++ b/src/avresponse.jl
@@ -4,7 +4,7 @@ struct AlphaVantageResponse
     data::Vector{AbstractVector}
     names::Vector{AbstractString}
 
-    AlphaVantageResponse(data::Vector{AbstractVector}, names::Vector{AbstractString}) = begin
+    AlphaVantageResponse(data::Vector{AbstractVector}, names::Vector{<:AbstractString}) = begin
         l1 = length(data[1])
         @assert all(t -> length(t) == l1, data)
         @assert length(data) == length(names)
@@ -12,17 +12,22 @@ struct AlphaVantageResponse
     end
 end
 
-AlphaVantageResponse(data::Vector{Vector{T}} where T, names::Vector{String}) = begin
-    AlphaVantageResponse(AbstractVector[d for d in data], names)
+function narrow_types(v::AbstractVector)
+    T = mapreduce(typeof, promote_type, v)
+    convert(AbstractVector{T}, v)
 end
 
-AlphaVantageResponse(data::Matrix{T} where T, names::Matrix{AbstractString}) = begin
-    v = AbstractVector[c for c in eachcol(data)]
+AlphaVantageResponse(data::AbstractVector{<:AbstractVector{T}} where T, names::AbstractVector{<:AbstractString}) = begin
+    AlphaVantageResponse(narrow_types(data), names)
+end
+
+AlphaVantageResponse(data::AbstractMatrix{T} where T, names::AbstractMatrix{<:AbstractString}) = begin
+    v = AbstractVector[narrow_types(c) for c in eachcol(data)]
     n = vec(names)
     AlphaVantageResponse(v, n)
 end
 
-AlphaVantageResponse(raw::Tuple{Matrix{Any}, Matrix{AbstractString}}) = begin
+AlphaVantageResponse(raw::Tuple{AbstractMatrix{Any}, AbstractMatrix{<:AbstractString}}) = begin
     AlphaVantageResponse(raw[1], raw[2])
 end
 


### PR DESCRIPTION
Currently, if you call `DataFrame` on an `AlphaVantageResponse` object, you get a bunch of columns with eltype `Any`. This is kind of annoying, since each column really has the same type. 

This fix here is a "quick fix", since we still allocate a `Matrix{Any}` at some point. But I don't want to add CSV.jl as a dependency. Not sure what the best strategy is long term. 